### PR TITLE
Yes, we can delete patch as update does already the job

### DIFF
--- a/ast.json
+++ b/ast.json
@@ -5,8 +5,8 @@
       "params": [
         "resourceType",
         "data",
-        "options",
-        "callback"
+        null,
+        null
       ],
       "docs": {
         "description": "Create a record",
@@ -128,7 +128,7 @@
           }
         ]
       },
-      "valid": true
+      "valid": false
     },
     {
       "name": "update",
@@ -136,8 +136,8 @@
         "resourceType",
         "path",
         "data",
-        "options",
-        "callback"
+        null,
+        null
       ],
       "docs": {
         "description": "Update data. A generic helper function to update a resource object of any type.\nUpdating an object requires to send `all required fields` or the `full body`",
@@ -268,15 +268,15 @@
           }
         ]
       },
-      "valid": true
+      "valid": false
     },
     {
       "name": "get",
       "params": [
         "resourceType",
         "query",
-        "options",
-        "callback"
+        null,
+        null
       ],
       "docs": {
         "description": "Get data. Generic helper method for getting data of any kind from DHIS2.\n- This can be used to get `DataValueSets`,`events`,`trackedEntityInstances`,`etc.`",
@@ -358,7 +358,7 @@
           }
         ]
       },
-      "valid": true
+      "valid": false
     },
     {
       "name": "discover",
@@ -415,103 +415,13 @@
       "valid": true
     },
     {
-      "name": "patch",
-      "params": [
-        "resourceType",
-        "path",
-        "data",
-        "options",
-        "callback"
-      ],
-      "docs": {
-        "description": "Patch a record. A generic helper function to send partial updates on one or more object properties.\n- You are not required to send the full body of object properties.\n- This is useful for cases where you don't want or need to update all properties on a object.",
-        "tags": [
-          {
-            "title": "public",
-            "description": null,
-            "type": null
-          },
-          {
-            "title": "function",
-            "description": null,
-            "name": null
-          },
-          {
-            "title": "param",
-            "description": "The type of resource to be updated. E.g. `dataElements`, `organisationUnits`, etc.",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "resourceType"
-          },
-          {
-            "title": "param",
-            "description": "The `id` or `path` to the `object` to be updated. E.g. `FTRrcoaog83` or `FTRrcoaog83/{collection-name}/{object-id}`",
-            "type": {
-              "type": "NameExpression",
-              "name": "string"
-            },
-            "name": "path"
-          },
-          {
-            "title": "param",
-            "description": "Data to update. Include only the fields you want to update. E.g. `{name: \"New Name\"}`",
-            "type": {
-              "type": "NameExpression",
-              "name": "Object"
-            },
-            "name": "data"
-          },
-          {
-            "title": "param",
-            "description": "Optional configuration, including params for the update ({preheatCache: true, strategy: 'UPDATE', mergeMode: 'REPLACE'}). Defaults to `{operationName: 'patch', apiVersion: state.configuration.apiVersion, responseType: 'json'}`",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "Object"
-              }
-            },
-            "name": "options"
-          },
-          {
-            "title": "param",
-            "description": "Optional callback to handle the response",
-            "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "function"
-              }
-            },
-            "name": "callback"
-          },
-          {
-            "title": "returns",
-            "description": null,
-            "type": {
-              "type": "NameExpression",
-              "name": "Operation"
-            }
-          },
-          {
-            "title": "example",
-            "description": "patch('dataElements', 'FTRrcoaog83', { name: 'New Name' });",
-            "caption": "a dataElement"
-          }
-        ]
-      },
-      "valid": true
-    },
-    {
       "name": "destroy",
       "params": [
         "resourceType",
         "path",
-        "data",
-        "options",
-        "callback"
+        null,
+        null,
+        null
       ],
       "docs": {
         "description": "Delete a record. A generic helper function to delete an object",
@@ -620,7 +530,7 @@
           }
         ]
       },
-      "valid": true
+      "valid": false
     },
     {
       "name": "findAttributeValue",

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -8,7 +8,6 @@ exports.create = create;
 exports.update = update;
 exports.get = get;
 exports.discover = discover;
-exports.patch = patch;
 exports.destroy = destroy;
 exports.findAttributeValue = findAttributeValue;
 exports.attr = attr;
@@ -640,52 +639,6 @@ function discover(httpMethod, endpoint) {
       return { ...state,
         data: result.data
       };
-    });
-  };
-}
-/**
- * Patch a record. A generic helper function to send partial updates on one or more object properties.
- * - You are not required to send the full body of object properties.
- * - This is useful for cases where you don't want or need to update all properties on a object.
- * @public
- * @function
- * @param {string} resourceType - The type of resource to be updated. E.g. `dataElements`, `organisationUnits`, etc.
- * @param {string} path - The `id` or `path` to the `object` to be updated. E.g. `FTRrcoaog83` or `FTRrcoaog83/{collection-name}/{object-id}`
- * @param {Object} data - Data to update. Include only the fields you want to update. E.g. `{name: "New Name"}`
- * @param {Object} [options] - Optional configuration, including params for the update ({preheatCache: true, strategy: 'UPDATE', mergeMode: 'REPLACE'}). Defaults to `{operationName: 'patch', apiVersion: state.configuration.apiVersion, responseType: 'json'}`
- * @param {function} [callback] - Optional callback to handle the response
- * @returns {Operation}
- * @example <caption>a dataElement</caption>
- * patch('dataElements', 'FTRrcoaog83', { name: 'New Name' });
- */
-// TODO: @Elias, can this be deleted in favor of update? How does DHIS2 handle PATCH vs PUT?
-// I need to investigate on this. But I think DHIS2 forces to send all properties back when we do an update. If that's confirmed then this may be needed.
-
-
-function patch(resourceType, path, data, options = {}, callback = false) {
-  return state => {
-    console.log('Preparing patch operation...');
-    resourceType = (0, _languageCommon.expandReferences)(resourceType)(state);
-    path = (0, _languageCommon.expandReferences)(path)(state);
-    data = (0, _languageCommon.expandReferences)(data)(state);
-    options = (0, _languageCommon.expandReferences)(options)(state);
-    const {
-      params,
-      requestConfig
-    } = options;
-    const {
-      configuration
-    } = state;
-    return (0, _Client.request)(configuration, {
-      method: 'patch',
-      url: (0, _Utils.generateUrl)(configuration, options, resourceType, path),
-      params,
-      data,
-      ...requestConfig
-    }).then(result => {
-      _Utils.Log.success(`Patched ${resourceType} at ${path}`);
-
-      return (0, _Utils.handleResponse)(result, state, callback);
     });
   };
 }

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -599,54 +599,6 @@ export function discover(httpMethod, endpoint) {
 }
 
 /**
- * Patch a record. A generic helper function to send partial updates on one or more object properties.
- * - You are not required to send the full body of object properties.
- * - This is useful for cases where you don't want or need to update all properties on a object.
- * @public
- * @function
- * @param {string} resourceType - The type of resource to be updated. E.g. `dataElements`, `organisationUnits`, etc.
- * @param {string} path - The `id` or `path` to the `object` to be updated. E.g. `FTRrcoaog83` or `FTRrcoaog83/{collection-name}/{object-id}`
- * @param {Object} data - Data to update. Include only the fields you want to update. E.g. `{name: "New Name"}`
- * @param {Object} [options] - Optional configuration, including params for the update ({preheatCache: true, strategy: 'UPDATE', mergeMode: 'REPLACE'}). Defaults to `{operationName: 'patch', apiVersion: state.configuration.apiVersion, responseType: 'json'}`
- * @param {function} [callback] - Optional callback to handle the response
- * @returns {Operation}
- * @example <caption>a dataElement</caption>
- * patch('dataElements', 'FTRrcoaog83', { name: 'New Name' });
- */
-// TODO: @Elias, can this be deleted in favor of update? How does DHIS2 handle PATCH vs PUT?
-// I need to investigate on this. But I think DHIS2 forces to send all properties back when we do an update. If that's confirmed then this may be needed.
-export function patch(
-  resourceType,
-  path,
-  data,
-  options = {},
-  callback = false
-) {
-  return state => {
-    console.log('Preparing patch operation...');
-
-    resourceType = expandReferences(resourceType)(state);
-    path = expandReferences(path)(state);
-    data = expandReferences(data)(state);
-    options = expandReferences(options)(state);
-
-    const { params, requestConfig } = options;
-    const { configuration } = state;
-
-    return request(configuration, {
-      method: 'patch',
-      url: generateUrl(configuration, options, resourceType, path),
-      params,
-      data,
-      ...requestConfig,
-    }).then(result => {
-      Log.success(`Patched ${resourceType} at ${path}`);
-      return handleResponse(result, state, callback);
-    });
-  };
-}
-
-/**
  * Delete a record. A generic helper function to delete an object
  * @public
  * @function


### PR DESCRIPTION
In DHIS2 it's very possible to update a resource by just sending the parts we wanna update. Expression's like this:
```javascript
update('programStages', 'eaDHS084uMp', {
  name: 'ANC 1st visit',
});
```
work very well.